### PR TITLE
Fix typescript compilation issues

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,5 +2,9 @@
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.7"
+  },
+  "tasks": {
+    "build": "deno compile --allow-all -o dist/apw src/cli.ts",
+    "bin": "./dist/apw start"
   }
 }

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
-export { Command } from "@cliffy/command";
+export { Command, ValidationError } from "@cliffy/command";
 export { Input, Select } from "@cliffy/prompt";
 export { Buffer } from "node:buffer";
 export { createSocket, type RemoteInfo } from "node:dgram";


### PR DESCRIPTION
Per #6 apw isn't able to be installed from homebrew due to Typescript error. I replaced the offending lines which catch errors with the default example from [the Cliffy documentation](https://cliffy.io/docs@v1.0.0-rc.4/command/error-handling). I don't have experience with Deno or Cliffy, but this way doesn't look like it should cause any more issues. I'm at least able to transpile and run the program now.

I've also included a build and run task in the deno.json.

Thanks for making a great utility! It works splendidly with the Raycast extension as well 😊