### PR TITLE
Adding feature to save account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist
 
 # Other
 *.psd
+
+# Binary
+apw

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Options:
 Commands:
 
   auth   - Authenticate CLI with daemon.         
-  pw     - Interactively list accounts/passwords.
+  pw     - Interactively list or save accounts/passwords.
   otp    - Interactively list accounts/OTPs.     
   start  - Start the daemon.
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,9 @@ const PrintEntries = (payload: Payload) => {
   if (payload.STATUS !== Status.SUCCESS) {
     throw new APWError(payload.STATUS);
   }
+  if (!payload.Entries) {
+    throw new APWError(Status.GENERIC_ERROR, "No entries found.");
+  }
   const entries = payload.Entries.map((entry) => {
     if ("USR" in entry) {
       return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ const pw = new Command()
   .action(async () => {
     const action: string = await Select.prompt({
       message: "Choose an action: ",
-      options: ["list accounts", "get password"],
+      options: ["list accounts", "get password", "save account"],
     });
     const url = await Input.prompt({
       message: "Enter URL: ",
@@ -80,6 +80,17 @@ const pw = new Command()
       PrintEntries(await client.getLoginNamesForURL(url));
     } else if (action === "get password") {
       PrintEntries(await client.getPasswordForURL(url));
+    } else if (action === "save account") {
+      const username = await Input.prompt({
+        message: "Enter username: ",
+      });
+      const password = await Input.prompt({
+        message: "Enter password: ",
+      });
+      if (!url || !username || !password) {
+        throw new Error("Missing required arguments 'url', 'username', or 'password'.");
+      }
+        await client.saveAccountForURL(url, username, password);
     }
   })
   .command("get", "Get a password for a website.")
@@ -97,7 +108,15 @@ const pw = new Command()
       throw new Error("Missing required argument 'url'.");
     }
     PrintEntries(await client.getLoginNamesForURL(url));
-  });
+  })
+  .command("save", "Save account/password for a website.")
+  .arguments("<url:string> <username:string> <password:string>")
+  .action(async (_, url: string, username: string, password: string) => {
+    if (!url || !username || !password) {
+      throw new Error("Missing required arguments 'url', 'username', or 'password'.");
+    }
+    await client.saveAccountForURL(url, username, password);
+});
 
 const daemon = new Command()
   .description("Start the daemon.")

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,6 +155,38 @@ export const APWMessages = {
       },
     };
   },
+
+  async newAccountForURL(
+    session: SRPSession,
+    url: string,
+    loginName: string,
+    password: string,
+  ): Promise<Message> {
+    const sdata = session.serialize(
+      await session.encrypt({
+        ACT: Action.MAYBE_ADD,
+        URL: String(),
+        USR: String(),
+        PWD: String(),
+        NURL: url,
+        NUSR: loginName,
+        NPWD: password,
+      }),
+    );
+
+    return {
+      cmd: Command.NEW_ACCOUNT_FOR_URL,
+      tabId: 0,
+      frameId: 0,
+      payload: JSON.stringify({
+        QID: "CmdNewAccount4URL",
+        SMSG: {
+          TID: session.username,
+          SDATA: sdata,
+        },
+      }),
+    };
+  },
 };
 
 export class ApplePasswordManager {
@@ -373,4 +405,20 @@ export class ApplePasswordManager {
     const response = await this.decryptPayload(payload);
     return response;
   }
+  async saveAccountForURL(url: string, loginName: string, password: string) {
+    const msg = await APWMessages.newAccountForURL(
+      this.session,
+      url,
+      loginName,
+      password,
+    );
+    const { payload } = await this.sendMessage(msg);
+    const response = await this.decryptPayload(payload);
+
+    if (response.STATUS !== Status.SUCCESS) {
+      throw new APWError(response.STATUS);
+    }
+    console.log("Account saved successfully."); 
+  }
+
 }

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,6 @@
 export const DATA_PATH = `${Deno.env.get("HOME")}/.apw`;
 
-export const VERSION = "1.0.1";
+export const VERSION = "1.0.2";
 
 export class APWError extends Error {
   code: Status;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,8 @@ export interface TOTPEntry {
 
 export interface Payload {
   STATUS: Status;
-  Entries: PasswordEntry[] | TOTPEntry[];
+  Entries?: PasswordEntry[] | TOTPEntry[];
+  RequiresUserAuthenticationToFill?: boolean;
 }
 
 export interface Capabilities {


### PR DESCRIPTION
@bendews, hope you like it 👍   

Implemented save to account feature per #8 

TL;DR

it doesn't validate if account tuple (url, loginname, password) already exists which means it can create or update the account seamlessly.

creating account...
</br>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/dd60b3f3-c078-4af1-9da6-13b73897040f" />
</br>
updating password...
</br>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1a5af697-0482-4439-b7da-4a8c75f74449" />

* Testing environment:
> Model Name:	MacBook Air
> Model Identifier:	Mac15,13
> Model Number:	MXD13BZ/A
> Chip:	Apple M3

* Version bumped to `1.0.2`  