### PR TITLE
Add LaunchBar action to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ APW is now running and ready to use.
 
 The following integrations have been completed:
 
-- Raycast [extension link](https://github.com/bendews/apw-raycast) to provide quick access to passwords and OTP tokens.
+- [Raycast extension](https://github.com/bendews/apw-raycast) to provide quick access to passwords and OTP tokens.
   Will automatically retrieve entries for the currently active webpage.
-- LaunchBar [action link](https://github.com/andesco/launchbar-apple-passwords) to provide quick access to passwords and OTP tokens.
+- [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) to provide quick access to passwords and OTP tokens.
   Finds entries for a typed domain and pastes the selected username, password, or one-time code.
 
 The following are some future integration ideas:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ APW is now running and ready to use.
 The following integrations provide quick access to passwords and OTP tokens:
 
 - [Raycast extension](https://github.com/bendews/apw-raycast) automatically retrieves entries for the currently active webpage.
-- [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) finds entries for a typed domain and pastes the selected username, password, or one-time code.
+- [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) finds entries for a typed domain and pastes the selected entry.
 
 The following are some future integration ideas:
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ APW is now running and ready to use.
 
 ## Integrations
 
-The following integrations have been completed:
+The following integrations provide quick access to passwords and OTP tokens:
 
-- [Raycast extension](https://github.com/bendews/apw-raycast) to provide quick access to passwords and OTP tokens.
-  Will automatically retrieve entries for the currently active webpage.
-- [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) to provide quick access to passwords and OTP tokens.
-  Finds entries for a typed domain and pastes the selected username, password, or one-time code.
+- [Raycast extension](https://github.com/bendews/apw-raycast) automatically retrieves entries for the currently active webpage.
+- [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) finds entries for a typed domain and pastes the selected username, password, or one-time code.
 
 The following are some future integration ideas:
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The following integrations have been completed:
 
 - Raycast [extension link](https://github.com/bendews/apw-raycast) to provide quick access to passwords and OTP tokens.
   Will automatically retrieve entries for the currently active webpage.
+- LaunchBar [action link](https://github.com/andesco/launchbar-apple-passwords) to provide quick access to passwords and OTP tokens.
+  Finds entries for a typed domain and pastes the selected username, password, or one-time code.
 
 The following are some future integration ideas:
 


### PR DESCRIPTION
## Summary
- Lists the [LaunchBar action](https://github.com/andesco/launchbar-apple-passwords) alongside the Raycast extension in **Integrations**.
- Tightens the list to a shared intro sentence ("The following integrations provide quick access to passwords and OTP tokens:") with each item as a short fragment, so both entries read consistently.

## Note
While editing this section I noticed the Raycast extension link (`https://github.com/bendews/apw-raycast`) currently 404s — the repo appears to be private or removed. Not fixed here since I don't know the intended destination; flagging in case it needs updating separately.
